### PR TITLE
Added clearProfiler

### DIFF
--- a/lib/src/fnx_profiler_base.dart
+++ b/lib/src/fnx_profiler_base.dart
@@ -4,6 +4,9 @@ bool profilerExceptions = true;
 
 Map<String, _ProfilerStats> _stats = {};
 
+/// Clears the profiler stats.
+void clearProfiler => _stats.clear();
+
 /// This is the entrypoint for your profiling.
 ///
 /// Open new root profiler and than add children to it.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fnx_profiler
 description: Imperative profiler for Dart applications.
-version: 0.9.1
+version: 0.9.2
 author: Tomáš Zvěřina <tomucha@gmail.com>
 homepage: https://github.com/fnx-io/fnx_profiler
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fnx_profiler
 description: Imperative profiler for Dart applications.
-version: 0.9.2
+version: 0.9.1
 author: Tomáš Zvěřina <tomucha@gmail.com>
 homepage: https://github.com/fnx-io/fnx_profiler
 


### PR DESCRIPTION
Adds a simple function that allows you to clear the profiler. I'm now using `fnx_profiler` in [`angel_diagnostics`](https://github.com/angel-dart/diagnostics), and being able to manually clear the profiler stats makes it easier to print on every request.